### PR TITLE
Fix machine port numbers in docker-compose-oscm.yml

### DIFF
--- a/oscm-deployer/templates/docker-compose-oscm-syslog.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm-syslog.yml.template
@@ -36,7 +36,7 @@ services:
       - ${DOCKER_PATH}/logs/oscm-core/tomcat:/opt/apache-tomee/logs
     ports:
       - 8081:8081
-      - 8000:8000
+      - 8080:8080
 
   oscm-app:
     image: ${IMAGE_APP}
@@ -60,7 +60,7 @@ services:
       - ${DOCKER_PATH}/logs/oscm-app/tomcat:/opt/apache-tomee/logs
     ports:
       - 8881:8881
-      - 8800:8000
+      - 8880:8880
 
   oscm-birt:
     image: ${IMAGE_BIRT}
@@ -96,7 +96,7 @@ services:
       - ${DOCKER_PATH}/config/oscm-branding/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
-      - 8443:443
+      - 8443:8443
 
   oscm-help:
     image: ${IMAGE_HELP}
@@ -107,4 +107,4 @@ services:
       options:
         syslog-facility: "local5"
     ports:
-      - 8543:443
+      - 8543:8543

--- a/oscm-deployer/templates/docker-compose-oscm-syslog.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm-syslog.yml.template
@@ -96,7 +96,7 @@ services:
       - ${DOCKER_PATH}/config/oscm-branding/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
-      - 8443:8443
+      - 8443:443
 
   oscm-help:
     image: ${IMAGE_HELP}
@@ -107,4 +107,4 @@ services:
       options:
         syslog-facility: "local5"
     ports:
-      - 8543:8543
+      - 8543:443

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -73,11 +73,11 @@ services:
       - ${DOCKER_PATH}/config/oscm-branding/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
-      - 8443:8443
+      - 8443:443
 
   oscm-help:
     image: ${IMAGE_HELP}
     container_name: oscm-help
     restart: always
     ports:
-      - 8543:8543
+      - 8543:443

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -27,7 +27,7 @@ services:
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
       - 8081:8081
-      - 8000:8000
+      - 8080:8080
 
   oscm-app:
     image: ${IMAGE_APP}
@@ -46,7 +46,7 @@ services:
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
       - 8881:8881
-      - 8800:8000
+      - 8880:8880
 
   oscm-birt:
     image: ${IMAGE_BIRT}
@@ -73,11 +73,11 @@ services:
       - ${DOCKER_PATH}/config/oscm-branding/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
-      - 8443:443
+      - 8443:8443
 
   oscm-help:
     image: ${IMAGE_HELP}
     container_name: oscm-help
     restart: always
     ports:
-      - 8543:443
+      - 8543:8543


### PR DESCRIPTION
The non-secure connection port numbers are hardcoded in the application in a few
places. This udpates the port numbers to match the expected ports in the
application.