### PR TITLE
Include rh-python36 and pip

### DIFF
--- a/oscm-centos-based/Dockerfile
+++ b/oscm-centos-based/Dockerfile
@@ -3,13 +3,14 @@ FROM centos:7
 RUN export http_proxy=$HTTP_PROXY && \
     export https_proxy=$HTTP_PROXY && \
     yum update -y && \
-    yum install -y https://centos7.iuscommunity.org/ius-release.rpm && \
+    yum install -y centos-release-scl \
     yum makecache fast && \
     yum install -y \
-        python36u-pip \
+        rh-python36 \
         unzip \
         wget \
         openssl \
         tcpdump \
         gettext && \
     yum clean all
+    

--- a/oscm-centos-based/Dockerfile
+++ b/oscm-centos-based/Dockerfile
@@ -3,7 +3,10 @@ FROM centos:7
 RUN export http_proxy=$HTTP_PROXY && \
     export https_proxy=$HTTP_PROXY && \
     yum update -y && \
+    yum install -y https://centos7.iuscommunity.org/ius-release.rpm && \
+    yum makecache fast && \
     yum install -y \
+        python36u-pip \
         unzip \
         wget \
         openssl \


### PR DESCRIPTION
For using pip use the scl bash.  You can run the bash with: 
`scl enable rh-python36 bash `