### PR TITLE
Add hot deploy

### DIFF
--- a/oscm-app/start.sh
+++ b/oscm-app/start.sh
@@ -35,9 +35,6 @@ done
 find /etc/pki/ca-trust/source/anchors -type f -name "*.p11-kit" -exec sed -i 's|^certificate-category: other-entry$|certificate-category: authority|g' {} \;
 /usr/bin/update-ca-trust
 
-# Import script files into execution folder
-find /import/scripts -type f -exec cp {} /opt/scripts \;
-
 # Add oscm-core to NOPROXY
 if [ -n "$PROXY_NOPROXY" ]; then
     export PROXY_NOPROXY="${PROXY_NOPROXY},oscm-core"

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -46,6 +46,7 @@ services:
       - ${DOCKER_PATH}/config/oscm-app/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/oscm-app/scripts:/import/scripts
       - ${DOCKER_PATH}/config/certs:/import/certs
+      - ${DOCKER_PATH}/config/certs:/opt/scripts
     ports:
       - 8881:8881
       - 8800:8000

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -44,9 +44,8 @@ services:
       - ${DOCKER_PATH}/config/oscm-app/ssl/privkey:/import/ssl/privkey
       - ${DOCKER_PATH}/config/oscm-app/ssl/cert:/import/ssl/cert
       - ${DOCKER_PATH}/config/oscm-app/ssl/chain:/import/ssl/chain
-      - ${DOCKER_PATH}/config/oscm-app/scripts:/import/scripts
-      - ${DOCKER_PATH}/config/certs:/import/certs
       - ${DOCKER_PATH}/config/oscm-app/scripts:/opt/scripts
+      - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
       - 8881:8881
       - 8800:8000

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -46,7 +46,7 @@ services:
       - ${DOCKER_PATH}/config/oscm-app/ssl/chain:/import/ssl/chain
       - ${DOCKER_PATH}/config/oscm-app/scripts:/import/scripts
       - ${DOCKER_PATH}/config/certs:/import/certs
-      - ${DOCKER_PATH}/config/certs:/opt/scripts
+      - ${DOCKER_PATH}/config/oscm-app/scripts:/opt/scripts
     ports:
       - 8881:8881
       - 8800:8000


### PR DESCRIPTION
Please note that the mountpoint (inside the container) is now located at /opt/scripts and no longer at /import/scripts. 