### PR TITLE
Map tenant properties files into oscm-identity container

### DIFF
--- a/oscm-deployer/start.sh
+++ b/oscm-deployer/start.sh
@@ -36,6 +36,7 @@ for docker_directory in \
     ${TARGET_PATH}/config/oscm-identity/ssl/privkey \
     ${TARGET_PATH}/config/oscm-identity/ssl/cert \
     ${TARGET_PATH}/config/oscm-identity/ssl/chain \
+    ${TARGET_PATH}/config/oscm-identity/tenants \
     ${TARGET_PATH}/config/oscm-birt/ssl/privkey \
     ${TARGET_PATH}/config/oscm-birt/ssl/cert \
     ${TARGET_PATH}/config/oscm-birt/ssl/chain \

--- a/oscm-deployer/templates/docker-compose-oscm.yml.template
+++ b/oscm-deployer/templates/docker-compose-oscm.yml.template
@@ -76,7 +76,7 @@ services:
       - ${DOCKER_PATH}/config/certs:/import/certs
     ports:
       - 8443:443
-      
+     
   oscm-identity:
     image: ${IMAGE_IDENTITY}
     container_name: oscm-identity
@@ -85,6 +85,8 @@ services:
     environment:
       - JPDA_ADDRESS=9000
       - JPDA_TRANSPORT=dt_socket
+    volumes:
+      - ${DOCKER_PATH}/config/oscm-identity/tenants:/opt/identity/config/tenants
     ports:
       - 9090:9090
       - 9000:9000    

--- a/oscm-identity/Dockerfile
+++ b/oscm-identity/Dockerfile
@@ -4,7 +4,8 @@ COPY ssl.crt /opt/ssl.crt
 COPY ssl.key /opt/ssl.key
 COPY ssl.crt /usr/share/pki/ca-trust-source/anchors
 
-RUN mkdir /opt/identity/ && \
+RUN mkdir /opt/identity && \
+    mkdir /opt/identity/config && \  
 	mkdir /opt/identity/config/tenants
 	
  

--- a/oscm-identity/Dockerfile
+++ b/oscm-identity/Dockerfile
@@ -4,6 +4,10 @@ COPY ssl.crt /opt/ssl.crt
 COPY ssl.key /opt/ssl.key
 COPY ssl.crt /usr/share/pki/ca-trust-source/anchors
 
+RUN mkdir /opt/identity/ && \
+	mkdir /opt/identity/config/tenants
+	
+ 
 RUN export http_proxy=$HTTP_PROXY && \
     export https_proxy=$HTTP_PROXY && \
     yum install -y \
@@ -16,12 +20,15 @@ RUN export http_proxy=$HTTP_PROXY && \
 ENV http_proxy=$HTTP_PROXY
 ENV https_proxy=$HTTP_PROXY
 
-COPY oscm-identity.jar /opt/main.jar
+ 
 
-COPY start.sh /opt/start.sh
+COPY oscm-identity.jar /opt/identity/main.jar
 
-RUN chmod +x /opt/start.sh
+COPY start.sh /opt/identity/start.sh
 
-CMD ["/opt/start.sh"]
+ 
+chmod +x /opt/identity/start.sh
+
+CMD ["/opt/identity/start.sh"]
 
 

--- a/oscm-identity/Dockerfile
+++ b/oscm-identity/Dockerfile
@@ -23,11 +23,9 @@ ENV https_proxy=$HTTP_PROXY
  
 
 COPY oscm-identity.jar /opt/identity/main.jar
-
 COPY start.sh /opt/identity/start.sh
-
  
-chmod +x /opt/identity/start.sh
+RUN chmod +x /opt/identity/start.sh
 
 CMD ["/opt/identity/start.sh"]
 

--- a/oscm-identity/start.sh
+++ b/oscm-identity/start.sh
@@ -4,4 +4,4 @@ HTTP_PROXY_PORT=$(echo $http_proxy | cut -d'/' -f3 | cut -d':' -f2)
 HTTPS_PROXY_HOST=$(echo $https_proxy | cut -d'/' -f3 | cut -d':' -f1)
 HTTPS_PROXY_PORT=$(echo $https_proxy | cut -d'/' -f3 | cut -d':' -f2)
 
-java -Dhttp.proxyHost=$PROXY_HTTP_HOST -Dhttp.proxyPort=$PROXY_HTTP_PORT -Dhttps.proxyHost=$PROXY_HTTPS_HOST -Dhttps.proxyPort=$PROXY_HTTPS_PORT -Djava.security.egd=file:/dev/./urandom -jar /opt/main.jar
+java -Dhttp.proxyHost=$PROXY_HTTP_HOST -Dhttp.proxyPort=$PROXY_HTTP_PORT -Dhttps.proxyHost=$PROXY_HTTPS_HOST -Dhttps.proxyPort=$PROXY_HTTPS_PORT -Djava.security.egd=file:/dev/./urandom -jar /opt/identity/main.jar


### PR DESCRIPTION
Allow operator to provide tenant mapping with properties files in the host directory
`/docker/config/oscm-identity/tenants`

All contained files have to match the name pattern `tentant-<name>.properties`, where `<name>` equals the ID of the tenant .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-dockerbuild/174)
<!-- Reviewable:end -->
