### PR TITLE
Adapt prepare.sh and Dockerfile for REST API deployment.

### DIFF
--- a/oscm-core/Dockerfile
+++ b/oscm-core/Dockerfile
@@ -15,6 +15,11 @@ COPY oscm.ear /opt/apache-tomee/apps
 COPY oscm-portal.war /opt/apache-tomee/webapps
 COPY oscm-portal-help.war /opt/apache-tomee/webapps
 
+#COPY oscm-rest-api-account.war /opt/apache-tomee/webapps
+# - || -
+# - || -
+# - || -
+
 COPY oscm-security.jar /opt/apache-tomee/lib/
 COPY oscm-common.jar /opt/apache-tomee/lib/
 COPY oscm-rest-api-common.jar /opt/apache-tomee/lib/

--- a/oscm-core/Dockerfile
+++ b/oscm-core/Dockerfile
@@ -15,10 +15,13 @@ COPY oscm.ear /opt/apache-tomee/apps
 COPY oscm-portal.war /opt/apache-tomee/webapps
 COPY oscm-portal-help.war /opt/apache-tomee/webapps
 
-#COPY oscm-rest-api-account.war /opt/apache-tomee/webapps
-# - || -
-# - || -
-# - || -
+COPY oscm-rest-api-event.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-operation.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-account.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-identity.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-service.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-marketplace.war /opt/apache-tomee/webapps
+COPY oscm-rest-api-subscription.war /opt/apache-tomee/webapps
 
 COPY oscm-security.jar /opt/apache-tomee/lib/
 COPY oscm-common.jar /opt/apache-tomee/lib/

--- a/oscm-core/Dockerfile
+++ b/oscm-core/Dockerfile
@@ -15,13 +15,7 @@ COPY oscm.ear /opt/apache-tomee/apps
 COPY oscm-portal.war /opt/apache-tomee/webapps
 COPY oscm-portal-help.war /opt/apache-tomee/webapps
 
-COPY oscm-rest-api-event.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-operation.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-account.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-identity.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-service.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-marketplace.war /opt/apache-tomee/webapps
-COPY oscm-rest-api-subscription.war /opt/apache-tomee/webapps
+COPY oscm-rest-api.war /opt/apache-tomee/webapps
 
 COPY oscm-security.jar /opt/apache-tomee/lib/
 COPY oscm-common.jar /opt/apache-tomee/lib/

--- a/prepare.sh
+++ b/prepare.sh
@@ -98,10 +98,13 @@ cp $BUILD_DIR/oscm-rest-api-common/oscm-rest-api-common.jar $REPO_DOCKER/oscm-co
 cp $LIB_DIR/apache-log4j/javalib/log4j-1.2.16.jar $REPO_DOCKER/oscm-core/
 
 # copy rest api for core
-#cp $REST_API/oscm-rest-api-account/target/oscm-rest-api-account.jar $REPO_DOCKER/oscm-core/
-# - || -
-# - || -
-# - || -
+cp $REST_API/oscm-rest-api-event/target/oscm-rest-api-event.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-operation/target/oscm-rest-api-operation.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-account/target/oscm-rest-api-account.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-identity/target/oscm-rest-api-identity.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-service/target/oscm-rest-api-service.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-marketplace/target/oscm-rest-api-marketplace.war $REPO_DOCKER/oscm-core/
+cp $REST_API/oscm-rest-api-subscription/target/oscm-rest-api-subscription.war $REPO_DOCKER/oscm-core/
 
 # copy resources for app
 cp $OSCM_APP/oscm-app-ear/target/oscm-app.ear $REPO_DOCKER/oscm-app/

--- a/prepare.sh
+++ b/prepare.sh
@@ -98,14 +98,8 @@ cp $BUILD_DIR/oscm-extsvc/oscm-extsvc-platform.jar $REPO_DOCKER/oscm-core/
 cp $BUILD_DIR/oscm-rest-api-common/oscm-rest-api-common.jar $REPO_DOCKER/oscm-core/
 cp $LIB_DIR/apache-log4j/javalib/log4j-1.2.16.jar $REPO_DOCKER/oscm-core/
 
-# copy rest api for core
-cp $REST_API/oscm-rest-api-event/target/oscm-rest-api-event.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-operation/target/oscm-rest-api-operation.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-account/target/oscm-rest-api-account.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-identity/target/oscm-rest-api-identity.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-service/target/oscm-rest-api-service.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-marketplace/target/oscm-rest-api-marketplace.war $REPO_DOCKER/oscm-core/
-cp $REST_API/oscm-rest-api-subscription/target/oscm-rest-api-subscription.war $REPO_DOCKER/oscm-core/
+# copy rest api war for core
+cp $REST_API/oscm-rest-api-uberwar/target/oscm-rest-api.war $REPO_DOCKER/oscm-core/
 
 # copy resources for app
 cp $OSCM_APP/oscm-app-ear/target/oscm-app.ear $REPO_DOCKER/oscm-app/

--- a/prepare.sh
+++ b/prepare.sh
@@ -4,6 +4,7 @@ REPO_DOCKER="`dirname \"$0\"`"
 REPO_OSCM="$1"
 BUILD_DIR="$REPO_OSCM/oscm-build/result/package"
 OSCM_APP="$REPO_OSCM/oscm-app-maven"
+REST_API="$REPO_OSCM/oscm-rest-api"
 BUILD_SHELL_DIR="$REPO_OSCM/oscm-app-shell/target"
 LIB_DIR="$REPO_OSCM/libraries"
 
@@ -95,6 +96,12 @@ cp $BUILD_DIR/oscm-server-common/oscm-server-common.jar $REPO_DOCKER/oscm-core/
 cp $BUILD_DIR/oscm-extsvc/oscm-extsvc-platform.jar $REPO_DOCKER/oscm-core/
 cp $BUILD_DIR/oscm-rest-api-common/oscm-rest-api-common.jar $REPO_DOCKER/oscm-core/
 cp $LIB_DIR/apache-log4j/javalib/log4j-1.2.16.jar $REPO_DOCKER/oscm-core/
+
+# copy rest api for core
+#cp $REST_API/oscm-rest-api-account/target/oscm-rest-api-account.jar $REPO_DOCKER/oscm-core/
+# - || -
+# - || -
+# - || -
 
 # copy resources for app
 cp $OSCM_APP/oscm-app-ear/target/oscm-app.ear $REPO_DOCKER/oscm-app/


### PR DESCRIPTION
In this pull request:

- Modify prepare.sh and oscm-core's Dockerfile to deploy oscm-rest-api.war into the oscm-core container.

This is part of https://github.com/servicecatalog/oscm-rest-api/issues/45
and has to be merged together with the changes on jenkins scripts for the jenkins build and push pipeline to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-dockerbuild/175)
<!-- Reviewable:end -->
