### PR TITLE
Allow JMX_REMOTE_PORT to connect MBean Server for internal ops

### DIFF
--- a/oscm-core/resources/setenv.sh
+++ b/oscm-core/resources/setenv.sh
@@ -10,4 +10,9 @@
  
 JAVA_OPTS=$JAVA_OPTS" -Dorg.apache.el.parser.SKIP_IDENTIFIER_CHECK=true"
 JAVA_OPTS=$JAVA_OPTS" -Djava.security.auth.login.config=/opt/apache-tomee/conf/jaas.config"
+
+if [ -n "$JMX_REMOTE_PORT" ]; then 
+  JAVA_OPTS=$JAVA_OPTS" -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$JMX_REMOTE_PORT -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+fi
+
 export JAVA_OPTS


### PR DESCRIPTION
**Changes in this Pull Request:**
- Added non-default internal option to allow JMX clients connecting the MBean Server in oscm-core container. This is useful for testing and debugging purpose.

**Mandatory checks:**
- [X] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [ ] changes were tested manually
- [ ] communication about interdependent changes has been sent to the team (if applicable)
- [ ] respective Jenkins jobs were referenced in *additional context* section of this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-dockerbuild/286)
<!-- Reviewable:end -->
