### PR TITLE
oscm proxy landing page and configuration for port 443 restricted environments

### DIFF
--- a/oscm-deployer/resources/index.html.template
+++ b/oscm-deployer/resources/index.html.template
@@ -25,8 +25,10 @@ body {
     <li><a href="/oscm-app">oscm-app</a> - The OSCM Provisioning Service.<br /></li>
     <li><a href="/oscm-app-vmware">oscm-app-vmware</a> - The VMware Connector for OSCM.<br /></li>
     <li><a href="/oscm-app-openstack">oscm-app-openstack</a> - The OpenStack Connector for OSCM.<br /></li>
+    <li><a href="/oscm-app-approval">oscm-app-approval</a> - Manage your OSCM Approval Settings.<br /></li>
     <li><a href="/oscm-app-azure">oscm-app-azure</a> - The MS Azure Connector for OSCM.<br /></li>
     <li><a href="/oscm-app-aws">oscm-app-aws</a> - The Amazon EC2 Connector for OSCM.<br /></li>
+    <li><a href="/approval">approval</a> - The OSCM Approval Web Tool.<br /></li>
     <li><a href="/birt">birt</a> - The OSCM Reporting Engine.<br /></li>
     <li><a href="/mail">mail</a> - A Mail Mock Service (for testing without Mail Server connections).<br />
     </p></li>

--- a/oscm-deployer/resources/proxy.conf.template
+++ b/oscm-deployer/resources/proxy.conf.template
@@ -29,16 +29,17 @@ server {
 
     ssl_certificate /etc/nginx/certs/cert/ssl.crt;
     ssl_certificate_key /etc/nginx/certs/privkey/ssl.key;
-
+    
     location /oscm-portal {
-        proxy_pass http://oscm-core:8080/oscm-portal;
+        proxy_pass https://oscm-core:8081/oscm-portal/;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 50m;
     }
 
+
     location /oscm-rest-api {
-        proxy_pass http://oscm-core:8080/oscm-rest-api;
+        proxy_pass https://oscm-core:8081/oscm-rest-api/;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 50m;
@@ -88,8 +89,16 @@ server {
     }
     
     location /oscm-app {
-        rewrite https://${FQDN}/oscm-app([^\n\r]*)$ http://oscm-app:8880/oscm-app$1 break;
-        proxy_pass http://oscm-app:8880;
+        rewrite https://${FQDN}/oscm-app([^\n\r]*)$ https://oscm-app:8881/oscm-app$1 break;
+        proxy_pass https://oscm-app:8881;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        client_max_body_size 50m;
+    }
+    
+    location /approval {
+        rewrite https://${FQDN}/approval([^\n\r]*)$ https://oscm-app:8881/approval$1 break;
+        proxy_pass https://oscm-app:8881;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 50m;


### PR DESCRIPTION
**Changes in this Pull Request:**
- Added approval tool and controller on proxy landing page  
- Fixed proxy rules for rewriting HTTPS URLs  as needed in restricted environments.

**Mandatory checks:**
- [X] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [X] changes were tested manually
- [ ] communication about interdependent changes has been sent to the team (if applicable)
- [ ] respective Jenkins jobs were referenced in *additional context* section of this PR

**OSCM Build References:**
/Docker_OSCM/job/OSCM_Docker_Build_and_push/373/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-dockerbuild/300)
<!-- Reviewable:end -->
